### PR TITLE
fix: changed type of private_key from textarea to string for testing …

### DIFF
--- a/src/plugin/manager/protocol_manager.py
+++ b/src/plugin/manager/protocol_manager.py
@@ -28,8 +28,8 @@ class ProtocolManager(BaseManager):
                     "type": "string",
                     "examples": ["ffd23sdv3b"],
                 },
-                "service_account": {
-                    "description": "service account associated with the client app",
+                "service_account_id": {
+                    "description": "service account id associated with the client app",
                     "minLength": 22,
                     "title": "Service Account",
                     "type": "string",
@@ -53,7 +53,7 @@ class ProtocolManager(BaseManager):
                     "description": "private key associated with the client app",
                     "minLength": 1000,
                     "title": "Private Key",
-                    "type": "textarea",
+                    "type": "string",
                     "examples": [
                         "----BEGIN PRIVATE KEY---— .... ----END PRIVATE KEY---—"
                     ],


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [X] etc

### Description

Temporarily set the type of private_key on metadata part to string for testing purposes.

### Known issue